### PR TITLE
feat: rename the each validator to "all"

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ const result = validate(letterA, 'B');
 * [Composition](https://strickland.io/docs/Composition/index.html)
     * [Arrays of Validators](https://strickland.io/docs/Composition/ArraysOfValidators.html)
         * [every](https://strickland.io/docs/Composition/every.html)
-        * [each](https://strickland.io/docs/Composition/each.html)
+        * [all](https://strickland.io/docs/Composition/all.html)
         * [some](https://strickland.io/docs/Composition/some.html)
     * [Validating Objects](https://strickland.io/docs/Composition/ValidatingObjects.html)
         * [objectProps](https://strickland.io/docs/Composition/objectProps.html)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -22,7 +22,7 @@
 * [Composition](/docs/Composition/README.md)
     * [Arrays of Validators](/docs/Composition/ArraysOfValidators.md)
         * [every](/docs/Composition/every.md)
-        * [each](/docs/Composition/each.md)
+        * [all](/docs/Composition/all.md)
         * [some](/docs/Composition/some.md)
     * [Validating Objects](/docs/Composition/ValidatingObjects.md)
         * [objectProps](/docs/Composition/objectProps.md)

--- a/docs/Async/AutomaticRaceConditionHandling.md
+++ b/docs/Async/AutomaticRaceConditionHandling.md
@@ -7,14 +7,14 @@ In the race condition handling example, we saw the application code check the cu
 This is done by passing a function to `validateAsync` that retrieves the current value. With that function, `validateAsync` will check the value when async validation completes. If the value is unchanged, the `Promise` will resolve normally; if the value _did change_ during async validation, the `Promise` will be rejected. The rejection will include the async result, but your application typically will not consume it.
 
 ``` jsx
-const validateUsername = [
+const usernameValidator = [
     required(),
     length({minLength: 2, maxLength: 20}),
     usernameIsAvailableTwoStage
 ];
 
 let username = 'marty';
-let usernameResult = validate(validateUsername, username);
+let usernameResult = validate(usernameValidator, username);
 
 username = 'mcfly';
 
@@ -39,7 +39,7 @@ import {
     validateAsync, required, length
 } from 'strickland';
 
-const validateUsername = [
+const usernameValidator = [
     required(),
     length({minLength: 2, maxLength: 20}),
     usernameIsAvailableTwoStage
@@ -47,7 +47,7 @@ const validateUsername = [
 
 let username = 'marty';
 
-validateAsync(validateUsername, () => username)
+validateAsync(usernameValidator, () => username)
     .then((asyncResult) => {
         // async validation completed
     })

--- a/docs/Async/RaceConditions.md
+++ b/docs/Async/RaceConditions.md
@@ -5,14 +5,14 @@ A common pitfall with async validation is to ensure the value hasn't changed dur
 Let's take a look at handling this race condition in application code:
 
 ``` jsx
-const validateUsername = [
+const usernameValidator = [
     required(),
     length(2, 20),
     usernameIsAvailableTwoStage
 ];
 
 let username = 'marty';
-let usernameResult = validate(validateUsername, username);
+let usernameResult = validate(usernameValidator, username);
 
 username = 'mcfly';
 

--- a/docs/Async/TwoStageValidation.md
+++ b/docs/Async/TwoStageValidation.md
@@ -54,7 +54,7 @@ In the following example, the application will render the partial, synchronous v
 ``` jsx
 import validate, {required, length} from 'strickland';
 
-const validateUser = {
+const userValidator = {
     name: [
         required(),
         length(2, 20)
@@ -71,7 +71,7 @@ const user = {
     username: 'marty'
 };
 
-const result = validate(validateUser, user);
+const result = validate(userValidator, user);
 
 /*
     result = {

--- a/docs/Async/ValidatorArraysAndObjects.md
+++ b/docs/Async/ValidatorArraysAndObjects.md
@@ -1,6 +1,6 @@
 # Async Validator Arrays and Objects
 
-The `every`, `each`, `some`, and `objectProps` validators support async validators too. You can compose async validators together with any other validators. Here is an example showing sync and async validators mixed together with nested objects and arrays.
+The `every`, `all`, `some`, and `objectProps` validators support async validators too. You can compose async validators together with any other validators. Here is an example showing sync and async validators mixed together with nested objects and arrays.
 
 ``` jsx
 import {validateAsync, required, length} from 'strickland';
@@ -99,9 +99,9 @@ subsequent validators from getting called if earlier validators are already inva
 that multiple async validators in an array would then have their execution times added up before
 valid results can be returned.
 
-## each
+## all
 
-The `each` validator resolves all async prop validators in parallel. Because `each` will never short-circuit based on validation results, it uses `Promise.all()` to resolve the validators. Its async validators can therefore run in parallel, and it may sometimes be beneficial to use `each` explicitly when performing multiple async validations.
+The `all` validator resolves all async prop validators in parallel. Because `all` will never short-circuit based on validation results, it uses `Promise.all()` to resolve the validators. Its async validators can therefore run in parallel, and it may sometimes be beneficial to use `all` explicitly when performing multiple async validations.
 
 ## some
 

--- a/docs/Composition/AdvancedObjectValidation.md
+++ b/docs/Composition/AdvancedObjectValidation.md
@@ -8,7 +8,7 @@ import validate, {
 } from 'strickland';
 
 // Define the rules for first name, last name, and birthYear
-const validatePersonProps = objectProps({
+const personPropsValidator = objectProps({
     firstName: every([
         required(),
         length(2, 20)
@@ -36,9 +36,9 @@ function stanfordStricklandBornIn1925(person) {
     return true;
 }
 
-const validatePerson = every([
+const personValidator = every([
     required(),
-    validatePersonProps,
+    personPropsValidator,
     stanfordStricklandBornIn1925
 ]);
 
@@ -49,7 +49,7 @@ const person = {
     birthYear: 1925
 };
 
-const result = validate(validatePerson, person);
+const result = validate(personValidator, person);
 ```
 
 In this example, the following will be validated (in this order):

--- a/docs/Composition/ArraysOfValidators.md
+++ b/docs/Composition/ArraysOfValidators.md
@@ -65,5 +65,11 @@ const result = validate(mustExistWithLength5, '1234', {
 Strickland has a few built-in composition validators that operate over arrays of validators.
 
 * [every](every.md)
-* [each](each.md)
+    * Returns a valid result if all validators are valid
+    * Short-circuits upon the first invalid result
+* [all](all.md)
+    * Returns a valid result if all validators are valid
+    * Does not short-circuit, producing results for all validators
 * [some](some.md)
+    * Returns a valid result if any validator is valid
+    * Short-circuits upon the first valid result

--- a/docs/Composition/Conventions.md
+++ b/docs/Composition/Conventions.md
@@ -11,7 +11,7 @@ We can rewrite the example for validating a person's name and address more natur
 ``` jsx
 import validate, {required, length, range} from 'strickland';
 
-const validatePerson = [
+const personValidator = [
     required(),
     {
         name: [required(), length(5, 40)],
@@ -40,7 +40,7 @@ const person = {
     }
 };
 
-const result = validate(validatePerson, person);
+const result = validate(personValidator, person);
 
 // Result would be invalid because
 // address does not have a street

--- a/docs/Composition/NestedObjects.md
+++ b/docs/Composition/NestedObjects.md
@@ -7,7 +7,7 @@ import validate, {
     objectProps, required, length, range, every
 } from 'strickland';
 
-const validatePerson = objectProps({
+const personValidator = objectProps({
     name: every([required(), length(5, 40)]),
     address: objectProps({
         street: objectProps({
@@ -31,7 +31,7 @@ const person = {
     }
 };
 
-const result = validate(validatePerson, person);
+const result = validate(personValidator, person);
 ```
 
 Objects can be nested without any limits on depth. And any type of validator can be used anywhere in the tree.

--- a/docs/Composition/README.md
+++ b/docs/Composition/README.md
@@ -4,7 +4,7 @@ The examples we've seen so far only validate single values against single valida
 
 * [Arrays of Validators](ArraysOfValidators.md)
     * [every](every.md)
-    * [each](each.md)
+    * [all](all.md)
     * [some](some.md)
 * [Validating Objects](ValidatingObjects.md)
     * [With the objectProps Validator](objectProps.md)

--- a/docs/Composition/ValidatingObjects.md
+++ b/docs/Composition/ValidatingObjects.md
@@ -10,7 +10,7 @@ import validate, {
 } from 'strickland';
 
 // Define the rules for first name, last name, and birthYear
-const validateProps = {
+const personValidator = {
     firstName: every([
         required(),
         length(2, 20)
@@ -30,30 +30,30 @@ const person = {
 };
 
 // Validate the person's properties
-const personProps = {
-    firstName: validate(validateProps.firstName, person.firstName),
-    lastName: validate(validateProps.lastName, person.lastName),
-    birthYear: validate(validateProps.birthYear, person.birthYear)
+const personResult = {
+    firstName: validate(personValidator.firstName, person.firstName),
+    lastName: validate(personValidator.lastName, person.lastName),
+    birthYear: validate(personValidator.birthYear, person.birthYear)
 };
 ```
 
-With this example, we have very primitive object property validation. The `personProps` output includes the validation results for each property, but there isn't anything providing a top-level `isValid` prop on the results. Let's add that in.
+With this example, we have very primitive object property validation. The `personResult` output includes the validation results for each property, but there isn't anything providing a top-level `isValid` prop on the results. Let's add that in.
 
 ``` jsx
 // Validate the person's properties
-const personProps = {
+const personResult = {
     firstName: validate(rules.firstName, person.firstName),
     lastName: validate(rules.lastName, person.lastName),
     birthYear: validate(rules.birthYear, person.birthYear)
 };
 
-// Create a top-level result including the results from personProps
+// Create a top-level result including the results from personResult
 const result = {
-    personProps,
+    personResult,
     isValid: (
-        personProps.firstName.isValid &&
-        personProps.lastName.isValid &&
-        personProps.birthYear.isValid
+        personResult.firstName.isValid &&
+        personResult.lastName.isValid &&
+        personResult.birthYear.isValid
     ),
     value: person
 };

--- a/docs/Composition/all.md
+++ b/docs/Composition/all.md
@@ -1,13 +1,13 @@
-# Built-In Validator: each
+# Built-In Validator: all
 
-Strickland provides an `each` validator. The `each` validator operates over an array and it will only return a valid result if all validators in the array are valid. But `each` has a significant difference from `every`: `each` will always execute all validators, regardless of previous results. You can use `each` if all validators are safe to execute and you need to know all validator results, even if some are invalid.
+Strickland provides an `all` validator. The `all` validator operates over an array and it will only return a valid result if all validators in the array are valid. But `all` has a significant difference from `every`: `all` will always execute all validators, regardless of previous results. You can use `all` if all validators are safe to execute and you need to know all validator results, even if some are invalid.
 
 ## Parameters
 
-The first parameter to the `each` validator factory is the array of validators. Validator props can also be supplied either as an object or as a function that accepts context and returns a validator props object.
+The first parameter to the `all` validator factory is the array of validators. Validator props can also be supplied either as an object or as a function that accepts context and returns a validator props object.
 
 ``` jsx
-const atLeast5Chars = each(
+const atLeast5Chars = all(
     [
         required(),
         minLength(5)
@@ -17,7 +17,7 @@ const atLeast5Chars = each(
 
 const result = validate(atLeast5Chars, '1234');
 
-const requiredWithMinLength = each(
+const requiredWithMinLength = all(
     [
         required(),
         minLength((context) => ({minLength: context.minLength}))
@@ -28,18 +28,18 @@ const requiredWithMinLength = each(
 
 ## Result Properties
 
-* `each`: The array of validation results produced during validation
+* `all`: The array of validation results produced during validation
 
-The `each` validator adds an `each` property to the validation result with the validation results of each validator that was validated in the array of validators. The validation result property is named `each` to match the name of the validator (this is a common pattern in Strickland).
+The `all` validator adds an `all` property to the validation result with the validation results of all validators that were validated in the array of validators. The validation result property is named `all` to match the name of the validator (this is a common pattern in Strickland).
 
 ## Usage
 
 ``` jsx
 import validate, {
-    each, required, minLength, maxLength
+    all, required, minLength, maxLength
 } from 'strickland';
 
-const mustExistWithLength5to10 = each([
+const mustExistWithLength5to10 = all([
     required({message: 'Required'}),
     minLength({minLength: 5, message: 'Must have at least 5 characters'}),
     maxLength({maxLength: 10, message: 'Must have at most 10 characters'})
@@ -53,7 +53,7 @@ const result = validate(mustExistWithLength5to10, '1234');
         required: true,
         minLength: 5,
         message: 'Must have at most 10 characters',
-        each: [
+        all: [
             {
                 isValid: true,
                 value: '1234',
@@ -79,12 +79,12 @@ const result = validate(mustExistWithLength5to10, '1234');
 
 There are a few notable characteristics of this result:
 
-1. The properties from each executed validator are added to the top-level result
+1. The properties from all executed validators are added to the top-level result
     * The `required` validator added the `required: true` property to the result
     * The `minLength` validator added the `minLength: 5` property to the result
     * The `maxLength` validator added the `maxLength: 10` property to the result
 1. Property collisions are resolved using last-in-wins
     * In this example, the `message` from the `maxLength` validator replaced the messages provided by the `required` and `minLength` validators
-    * This behavior is consistent and predictable with Strickland, but limits how top-level result properties can be used with the `each` validator
+    * This behavior is consistent and predictable with Strickland, but limits how top-level result properties can be used with the `all` validator
 1. All validators are executed, even after the result is known to be invalid
 1. The top-level `isValid` prop on the result reflects the overall validation result

--- a/docs/Composition/every.md
+++ b/docs/Composition/every.md
@@ -1,6 +1,6 @@
 # Built-In Validator: every
 
-The `every` validator is built into Strickland. And it has a couple additional features not illustrated in the example implementation.
+Strickland provides an `every` validator. The `every` validator operates over an array and it will only return a valid result if all validators in the array are valid. The `every` validator will short-circuit (exit early) as soon as an invalid result is encountered. This allows chaining of validators where one validator's logic might depend on a previous validator already being valid.
 
 ## Parameters
 

--- a/docs/Composition/objectProps.md
+++ b/docs/Composition/objectProps.md
@@ -9,7 +9,7 @@ The first parameter to the `objectProps` validator factory is an object defining
 ``` jsx
 import {objectProps} from 'strickland';
 
-const validateProps = objectProps({
+const personValidator = objectProps({
     firstName: every([required(), length(2, 20)]),
     lastName: every([required(), length(2, 20)]),
     birthYear: range(1900, 2018)
@@ -25,7 +25,7 @@ When validation context needs to be supplied to specific validators, an `objectP
 ``` jsx
 import {objectProps} from 'strickland';
 
-const validateProps = objectProps({
+const personValidator = objectProps({
     firstName: every([
         required(),
         length((context) => ({
@@ -55,7 +55,7 @@ const person = {
     birthYear: 1925
 };
 
-const result = validate(validateProps, person, {
+const result = validate(personValidator, person, {
     objectProps: {
         firstName: {
             minLength: 5,
@@ -86,7 +86,7 @@ import validate, {
 } from 'strickland';
 
 // Define the rules for first name, last name, and birthYear
-const validatePersonProps = objectProps({
+const personValidator = objectProps({
     firstName: every([required(), length(2, 20)]),
     lastName: every([required(), length(2, 20)]),
     birthYear: range(1900, 2018)
@@ -99,7 +99,7 @@ const person = {
     birthYear: 1925
 };
 
-const result = validate(validatePersonProps, person);
+const result = validate(personValidator, person);
 
 /*
     result = {

--- a/docs/Composition/some.md
+++ b/docs/Composition/some.md
@@ -1,6 +1,6 @@
 # Built-In Validator: some
 
-Strickland provides a `some` validator. The `some` validator operates over an array of validators and it behaves similarly to `every`, except that it will exit as soon as it encounters a *valid* result. If any of the validators in the array are valid, then the overall result will be valid.
+Strickland provides a `some` validator. The `some` validator operates over an array of validators and it will exit as soon as it encounters a *valid* result. If any of the validators in the array are valid, then the overall result will be valid.
 
 ## Parameters
 

--- a/docs/Forms/emptyResults.md
+++ b/docs/Forms/emptyResults.md
@@ -5,7 +5,7 @@ Applications that maintain validation state for interaction generally need to in
 ## Usage
 
 ``` jsx
-const validatePerson = form({
+const personValidator = form({
     firstName: [
         required(),
         length({minLength: 2, maxLength: 20})
@@ -17,7 +17,7 @@ const validatePerson = form({
     birthYear: range({min: 1900, max: 2018})
 });
 
-let validationResult = validatePerson.emptyResults();
+let validationResult = personValidator.emptyResults();
 
 /*
     validationResult = {

--- a/docs/Forms/form.md
+++ b/docs/Forms/form.md
@@ -39,7 +39,7 @@ import validate, {
     form, required, length, range
 } from 'strickland';
 
-const validatePerson = form({
+const personValidator = form({
     firstName: [
         required(),
         length(2, 20)
@@ -57,7 +57,7 @@ let person = {
 };
 
 // Validate the firstName field
-let result = validate(validatePerson, person, {
+let result = validate(personValidator, person, {
     form: {
         fields: ['firstName']
     }
@@ -93,7 +93,7 @@ person = {
 
 // Validate the lastName field, build on
 // previous form validation results
-result = validate(validatePerson, person, {
+result = validate(personValidator, person, {
     form: {
         ...result.form,
         fields: ['lastName']
@@ -137,7 +137,7 @@ person = {
 };
 
 // Validate the birthYear field
-result = validate(validatePerson, person, {
+result = validate(personValidator, person, {
     form: {
         ...result.form,
         fields: ['birthYear']
@@ -190,5 +190,5 @@ result = validate(validatePerson, person, {
 
 // Revalidate the entire form, passing
 // previous validation results in
-result = validate(validatePerson, person, result);
+result = validate(personValidator, person, result);
 ```

--- a/docs/Forms/updateFieldResults.md
+++ b/docs/Forms/updateFieldResults.md
@@ -7,7 +7,7 @@ To assist with such scenarios, Strickland's `form` validator offers an `updateFi
 ## Usage
 
 ```jsx
-const validatePerson = form({
+const personValidator = form({
     firstName: [
         required(),
         length({minLength: 2, maxLength: 20})
@@ -25,7 +25,7 @@ let stanfordStrickland = {
     birthYear: 1925
 };
 
-let stanfordResult = validate(validatePerson, stanfordStrickland);
+let stanfordResult = validate(personValidator, stanfordStrickland);
 
 let firstNameResult = {
     isValid: false,
@@ -33,7 +33,7 @@ let firstNameResult = {
     message: 'The service does not allow a first name of "Stanford"'
 };
 
-stanfordResult = validatePerson.updateFieldResults(
+stanfordResult = personValidator.updateFieldResults(
     stanfordResult,
     {firstName: firstNameResult}
 );
@@ -73,7 +73,7 @@ stanfordResult = validatePerson.updateFieldResults(
 To remove a field's results, provide `null` as the value of the field result.
 
 ``` jsx
-stanfordResult = validatePerson.updateFieldResults(
+stanfordResult = personValidator.updateFieldResults(
     stanfordResult,
     {firstName: null}
 );

--- a/docs/Forms/validateFields.md
+++ b/docs/Forms/validateFields.md
@@ -9,7 +9,7 @@ import validate, {
     form, required, length, range
 } from 'strickland';
 
-const validatePerson = form({
+const personValidator = form({
     firstName: [
         required(),
         length({minLength: 2, maxLength: 20})
@@ -27,7 +27,7 @@ let person = {
 };
 
 // Validate the firstName field
-let result = validate(validatePerson, person, {
+let result = validate(personValidator, person, {
     form: {
         fields: ['firstName']
     }
@@ -41,7 +41,7 @@ import validate, {
     form, required, length, range
 } from 'strickland';
 
-const validatePerson = form({
+const personValidator = form({
     firstName: [
         required(),
         length({minLength: 2, maxLength: 20})
@@ -59,7 +59,7 @@ let person = {
 };
 
 // Validate the firstName field
-let validationResult = validatePerson.validateFields(person, ['firstName']);
+let validationResult = personValidator.validateFields(person, ['firstName']);
 ```
 
 Once initial validation has occurred, `validateFields` can accept existing validation results to be updated during field-level validation.
@@ -68,7 +68,7 @@ Once initial validation has occurred, `validateFields` can accept existing valid
 // The firstName field has already been validated
 // Validate the lastName field
 
-validationResult = validatePerson.validateFields(
+validationResult = personValidator.validateFields(
     person,
     ['lastName'],
     validationResult

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@
 * [Composition](/docs/Composition/README.md)
     * [Arrays of Validators](/docs/Composition/ArraysOfValidators.md)
         * [every](/docs/Composition/every.md)
-        * [each](/docs/Composition/each.md)
+        * [all](/docs/Composition/all.md)
         * [some](/docs/Composition/some.md)
     * [Validating Objects](/docs/Composition/ValidatingObjects.md)
         * [objectProps](/docs/Composition/objectProps.md)

--- a/strickland/README.md
+++ b/strickland/README.md
@@ -98,7 +98,7 @@ const result = validate(letterA, 'B');
 * [Composition](https://strickland.io/docs/Composition/index.html)
     * [Arrays of Validators](https://strickland.io/docs/Composition/ArraysOfValidators.html)
         * [every](https://strickland.io/docs/Composition/every.html)
-        * [each](https://strickland.io/docs/Composition/each.html)
+        * [all](https://strickland.io/docs/Composition/all.html)
         * [some](https://strickland.io/docs/Composition/some.html)
     * [Validating Objects](https://strickland.io/docs/Composition/ValidatingObjects.html)
         * [objectProps](https://strickland.io/docs/Composition/objectProps.html)

--- a/strickland/src/all.js
+++ b/strickland/src/all.js
@@ -2,15 +2,15 @@ import validate from './validate';
 
 const initialResult = {
     isValid: true,
-    each: []
+    all: []
 };
 
-export default function eachValidator(validators, validatorProps) {
+export default function allValidator(validators, validatorProps) {
     if (!validators || !Array.isArray(validators)) {
-        throw 'Strickland: The `each` validator expects an array of validators';
+        throw 'Strickland: The `all` validator expects an array of validators';
     }
 
-    return function validateEach(value, context) {
+    return function validateAll(value, context) {
         let result = initialResult;
 
         const props = typeof validatorProps === 'function' ?
@@ -27,7 +27,7 @@ export default function eachValidator(validators, validatorProps) {
 
         if (hasAsyncResults) {
             result.validateAsync = function resolveAsync() {
-                const promises = result.each.map(
+                const promises = result.all.map(
                     (eachResult) => Promise.resolve(
                         eachResult.validateAsync ? eachResult.validateAsync() : eachResult
                     )
@@ -56,8 +56,8 @@ function applyNextResult(previousResult, nextResult) {
         ...previousResult,
         ...nextResult,
         isValid: previousResult.isValid && nextResult.isValid,
-        each: [
-            ...previousResult.each,
+        all: [
+            ...previousResult.all,
             nextResult
         ]
     };

--- a/strickland/src/strickland.js
+++ b/strickland/src/strickland.js
@@ -1,7 +1,7 @@
 export {default, validateAsync} from './validate';
 
 export {default as compare} from './compare';
-export {default as each} from './each';
+export {default as all} from './all';
 export {default as every} from './every';
 export {default as length} from './length';
 export {default as max} from './max';

--- a/strickland/test/all.spec.js
+++ b/strickland/test/all.spec.js
@@ -1,29 +1,29 @@
-import {each, required, minLength, maxLength} from '../src/strickland';
+import {all, required, minLength, maxLength} from '../src/strickland';
 
-describe('each', () => {
+describe('all', () => {
     describe('throws', () => {
         it('when no validators are specified', () => {
-            expect(() => each()).toThrow();
+            expect(() => all()).toThrow();
         });
 
         it('when validators is a function', () => {
-            expect(() => each(() => true)).toThrow();
+            expect(() => all(() => true)).toThrow();
         });
     });
 
     it('returns a validate function', () => {
-        const validate = each([]);
+        const validate = all([]);
         expect(validate).toBeInstanceOf(Function);
     });
 
     it('defaults to valid when validators is empty', () => {
-        const validate = each([]);
+        const validate = all([]);
         const result = validate();
         expect(result.isValid).toBe(true);
     });
 
     describe('validates', () => {
-        const validate = each([
+        const validate = all([
             required({message: 'Required'}),
             minLength(2),
             maxLength(4)
@@ -36,13 +36,13 @@ describe('each', () => {
             expect(result).toBeInstanceOf(Object);
         });
 
-        it('returning an each array on the result', () => {
-            expect(result.each).toBeInstanceOf(Array);
+        it('returning an all array on the result', () => {
+            expect(result.all).toBeInstanceOf(Array);
         });
 
-        it('returning results for each validator (including after invalid results)', () => {
+        it('returning results for all validators (including after invalid results)', () => {
             expect(result).toMatchObject({
-                each: [
+                all: [
                     {isValid: true, message: 'Required'},
                     {isValid: false, minLength: 2},
                     {isValid: true, maxLength: 4}
@@ -58,7 +58,7 @@ describe('each', () => {
             const validResult = validate('ABC');
             expect(validResult).toMatchObject({
                 isValid: true,
-                each: [
+                all: [
                     {isValid: true, message: 'Required'},
                     {isValid: true, minLength: 2},
                     {isValid: true, maxLength: 4}
@@ -73,16 +73,16 @@ describe('each', () => {
         it('resolving validator props from a function', () => {
             const getProps = jest.fn();
             const context = {contextProp: 'context'};
-            each([], getProps)(null, context);
+            all([], getProps)(null, context);
 
             expect(getProps).toHaveBeenCalledWith(context);
         });
     });
 
     describe('with nested rules arrays', () => {
-        const validate = each([
+        const validate = all([
             required({message: 'Required'}),
-            each([
+            all([
                 minLength(2),
                 maxLength(4)
             ])
@@ -92,11 +92,11 @@ describe('each', () => {
             const result = validate('ABC');
 
             expect(result).toMatchObject({
-                each: [
+                all: [
                     {isValid: true, message: 'Required'},
                     {
                         isValid: true,
-                        each: [
+                        all: [
                             {isValid: true, minLength: 2},
                             {isValid: true, maxLength: 4}
                         ]
@@ -113,13 +113,13 @@ describe('each', () => {
                 });
             }
 
-            const validateWithResultProps = each([
+            const validateWithResultProps = all([
                 resultPropValidator({first: 'First'}),
                 resultPropValidator({second: 'Second'}),
-                each([
+                all([
                     resultPropValidator({third: 'Third'}),
                     resultPropValidator({fourth: 'Fourth'}),
-                    each([
+                    all([
                         resultPropValidator({fifth: 'Fifth'})
                     ])
                 ])
@@ -140,7 +140,7 @@ describe('each', () => {
 
     it('passes context to the validators', () => {
         const validator = jest.fn();
-        const validate = each([validator], {validatorProp: 'Validator message'});
+        const validate = all([validator], {validatorProp: 'Validator message'});
 
         validate('AB', {contextProp: 'Context message'});
 
@@ -152,7 +152,7 @@ describe('each', () => {
     describe('given async validators', () => {
         describe('returns a validateAsync function', () => {
             it('that returns a Promise', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve(true)
                 ]);
 
@@ -161,8 +161,8 @@ describe('each', () => {
             });
 
             it('with exclusively nested results', () => {
-                const validateNested = each([
-                    each([
+                const validateNested = all([
+                    all([
                         () => Promise.resolve(true)
                     ])
                 ]);
@@ -171,10 +171,10 @@ describe('each', () => {
 
                 return expect(nestedResult.validateAsync()).resolves.toMatchObject({
                     isValid: true,
-                    each: [
+                    all: [
                         {
                             isValid: true,
-                            each: [{isValid: true}]
+                            all: [{isValid: true}]
                         }
                     ]
                 });
@@ -182,8 +182,8 @@ describe('each', () => {
         });
 
         describe('resolves results', () => {
-            it('resolves each result, even when some are invalid', () => {
-                const validate = each([
+            it('resolves all result, even when some are invalid', () => {
+                const validate = all([
                     () => ({isValid: false, first: 'First'}),
                     () => Promise.resolve({isValid: false, second: 'Second'}),
                     () => ({isValid: false, third: 'Third'}),
@@ -203,7 +203,7 @@ describe('each', () => {
             });
 
             it('that resolve as true', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve(true)
                 ]);
 
@@ -212,7 +212,7 @@ describe('each', () => {
             });
 
             it('that resolve as a valid result object', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve({isValid: true})
                 ]);
 
@@ -221,7 +221,7 @@ describe('each', () => {
             });
 
             it('that resolve as false', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve(false)
                 ]);
 
@@ -230,7 +230,7 @@ describe('each', () => {
             });
 
             it('that resolve as an invalid result object', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve({isValid: false})
                 ]);
 
@@ -239,7 +239,7 @@ describe('each', () => {
             });
 
             it('recursively', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve(
                         Promise.resolve(
                             Promise.resolve({
@@ -248,11 +248,11 @@ describe('each', () => {
                             })
                         )
                     ),
-                    each([
+                    all([
                         () => Promise.resolve(
                             Promise.resolve(true)
                         ),
-                        each([
+                        all([
                             () => Promise.resolve(
                                 Promise.resolve({
                                     isValid: true,
@@ -273,7 +273,7 @@ describe('each', () => {
             });
 
             it('puts the value on the resolved result', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve(true)
                 ]);
 
@@ -282,7 +282,7 @@ describe('each', () => {
             });
 
             it('puts validator props on the resolved result', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve(true)
                 ], {validatorProp: 'Validator message'})
 
@@ -291,7 +291,7 @@ describe('each', () => {
             });
 
             it('does not put context props on the resolved result', () => {
-                const validate = each([
+                const validate = all([
                     () => Promise.resolve(true)
                 ]);
 
@@ -301,10 +301,10 @@ describe('each', () => {
         });
 
         describe('returns a partial result object', () => {
-            const validate = each([
+            const validate = all([
                 () => ({isValid: true, first: 'First'}),
                 () => Promise.resolve({isValid: true, second: 'Second'}),
-                each([
+                all([
                     () => ({isValid: true, third: 'Third'}),
                     () => Promise.resolve({isValid: true, fourth: 'Fourth'}),
                     () => ({isValid: true, fifth: 'Fifth'})
@@ -324,13 +324,13 @@ describe('each', () => {
                     third: 'Third',
                     fifth: 'Fifth',
                     sixth: 'Sixth',
-                    each: [
+                    all: [
                         {first: 'First'},
                         {validateAsync: expect.any(Function)},
                         {
                             third: 'Third',
                             fifth: 'Fifth',
-                            each: [
+                            all: [
                                 {third: 'Third'},
                                 {validateAsync: expect.any(Function)},
                                 {fifth: 'Fifth'}
@@ -342,7 +342,7 @@ describe('each', () => {
             });
 
             it('with individual validator promises that will finish their results', () => {
-                return expect(result.each[2].each[1].validateAsync()).resolves.toMatchObject({
+                return expect(result.all[2].all[1].validateAsync()).resolves.toMatchObject({
                     isValid: true,
                     fourth: 'Fourth'
                 });

--- a/strickland/test/docs/async.spec.js
+++ b/strickland/test/docs/async.spec.js
@@ -218,7 +218,7 @@ describe('docs', () => {
                 };
             }
 
-            const validateUser = {
+            const userValidator = {
                 name: [
                     required(),
                     length(2, 20)
@@ -235,7 +235,7 @@ describe('docs', () => {
                 username: 'marty'
             };
 
-            const result = validate(validateUser, user);
+            const result = validate(userValidator, user);
 
             it('first stage', () => {
                 expect(result).toMatchObject({
@@ -288,14 +288,14 @@ describe('docs', () => {
                     expect.assertions(1);
                     const resultUsed = jest.fn();
 
-                    const validateUsername = [
+                    const usernameValidator = [
                         required(),
                         length(2, 20),
                         usernameIsAvailableTwoStage
                     ];
 
                     let username = 'marty';
-                    let usernameResult = validate(validateUsername, username);
+                    let usernameResult = validate(usernameValidator, username);
 
                     username = 'mcfly';
 
@@ -316,14 +316,14 @@ describe('docs', () => {
                 it('automatic race condition handling', () => {
                     expect.assertions(2);
 
-                    const validateUsername = [
+                    const usernameValidator = [
                         required(),
                         length({minLength: 2, maxLength: 20}),
                         usernameIsAvailableTwoStage
                     ];
 
                     let username = 'marty';
-                    let usernameResult = validate(validateUsername, username);
+                    let usernameResult = validate(usernameValidator, username);
 
                     username = 'mcfly';
 
@@ -354,7 +354,7 @@ describe('docs', () => {
                 it('automatic race condition handling in validateAsync', () => {
                     expect.assertions(2);
 
-                    const validateUsername = [
+                    const usernameValidator = [
                         required(),
                         length({minLength: 2, maxLength: 20}),
                         usernameIsAvailableTwoStage
@@ -365,7 +365,7 @@ describe('docs', () => {
                     const accepted = jest.fn();
                     const rejected = jest.fn();
 
-                    const promise = validateAsync(validateUsername, () => username)
+                    const promise = validateAsync(usernameValidator, () => username)
                         .then((asyncResult) => {
                             // async validation completed
                             accepted(asyncResult);

--- a/strickland/test/docs/composition.spec.js
+++ b/strickland/test/docs/composition.spec.js
@@ -8,7 +8,7 @@ import validate, {
     maxLength,
     length,
     every,
-    each,
+    all,
     some,
     objectProps
 } from '../../src/strickland';
@@ -135,9 +135,9 @@ describe('docs', () => {
             });
         });
 
-        describe('each', () => {
+        describe('all', () => {
             it('atLeast5Chars', () => {
-                const atLeast5Chars = each(
+                const atLeast5Chars = all(
                     [
                         required(),
                         minLength(5)
@@ -158,7 +158,7 @@ describe('docs', () => {
             });
 
             it('requiredWithMinLength', () => {
-                const requiredWithMinLength = each(
+                const requiredWithMinLength = all(
                     [
                         required(),
                         minLength((context) => ({minLength: context.minLength}))
@@ -179,7 +179,7 @@ describe('docs', () => {
             });
 
             it('mustExistWithLength5to10', () => {
-                const mustExistWithLength5to10 = each([
+                const mustExistWithLength5to10 = all([
                     required({message: 'Required'}),
                     minLength({minLength: 5, message: 'Must have at least 5 characters'}),
                     maxLength({maxLength: 10, message: 'Must have at most 10 characters'})
@@ -193,7 +193,7 @@ describe('docs', () => {
                     required: true,
                     minLength: 5,
                     message: 'Must have at most 10 characters',
-                    each: [
+                    all: [
                         {
                             isValid: true,
                             value: '1234',

--- a/strickland/test/docs/composition.spec.js
+++ b/strickland/test/docs/composition.spec.js
@@ -248,7 +248,7 @@ describe('docs', () => {
 
         it('validating objects', () => {
             // Define the rules for first name, last name, and birthYear
-            const validateProps = {
+            const personValidator = {
                 firstName: every([
                     required(),
                     length(2, 20)
@@ -268,19 +268,19 @@ describe('docs', () => {
             };
 
             // Validate the person's properties
-            const personProps = {
-                firstName: validate(validateProps.firstName, person.firstName),
-                lastName: validate(validateProps.lastName, person.lastName),
-                birthYear: validate(validateProps.birthYear, person.birthYear)
+            const personResult = {
+                firstName: validate(personValidator.firstName, person.firstName),
+                lastName: validate(personValidator.lastName, person.lastName),
+                birthYear: validate(personValidator.birthYear, person.birthYear)
             };
 
-            // Create a top-level result including the results from personProps
+            // Create a top-level result including the results from personResult
             const result = {
-                personProps,
+                personResult,
                 isValid: (
-                    personProps.firstName.isValid &&
-                    personProps.lastName.isValid &&
-                    personProps.birthYear.isValid
+                    personResult.firstName.isValid &&
+                    personResult.lastName.isValid &&
+                    personResult.birthYear.isValid
                 ),
                 value: person
             };
@@ -305,7 +305,7 @@ describe('docs', () => {
 
         describe('objectProps', () => {
             it('parameters', () => {
-                const validateProps = objectProps({
+                const personValidator = objectProps({
                     firstName: every([required(), length(2, 20)]),
                     lastName: every([required(), length(2, 20)]),
                     birthYear: range(1900, 2018)
@@ -313,7 +313,7 @@ describe('docs', () => {
                     message: 'The person must be valid'
                 });
 
-                const result = validate(validateProps, {});
+                const result = validate(personValidator, {});
 
                 expect(result).toMatchObject({
                     isValid: false,
@@ -322,7 +322,7 @@ describe('docs', () => {
             });
 
             it('validation context', () => {
-                const validateProps = objectProps({
+                const personValidator = objectProps({
                     firstName: every([
                         required(),
                         length((context) => ({
@@ -352,7 +352,7 @@ describe('docs', () => {
                     birthYear: 1925
                 };
 
-                const result = validate(validateProps, person, {
+                const result = validate(personValidator, person, {
                     objectProps: {
                         firstName: {
                             minLength: 5,
@@ -389,7 +389,7 @@ describe('docs', () => {
 
             it('result properties', () => {
                 // Define the rules for first name, last name, and birthYear
-                const validatePersonProps = objectProps({
+                const personValidator = objectProps({
                     firstName: every([required(), length(2, 20)]),
                     lastName: every([required(), length(2, 20)]),
                     birthYear: range(1900, 2018)
@@ -402,7 +402,7 @@ describe('docs', () => {
                     birthYear: 1925
                 };
 
-                const result = validate(validatePersonProps, person);
+                const result = validate(personValidator, person);
 
                 expect(result).toMatchObject({
                     isValid: true,
@@ -461,7 +461,7 @@ describe('docs', () => {
 
         it('advanced object validation', () => {
             // Define the rules for first name, last name, and birthYear
-            const validatePersonProps = objectProps({
+            const personPropsValidator = objectProps({
                 firstName: every([
                     required(),
                     length(2, 20)
@@ -489,9 +489,9 @@ describe('docs', () => {
                 return true;
             }
 
-            const validatePerson = every([
+            const personValidator = every([
                 required(),
-                validatePersonProps,
+                personPropsValidator,
                 stanfordStricklandBornIn1925
             ]);
 
@@ -502,12 +502,12 @@ describe('docs', () => {
                 birthYear: 1925
             };
 
-            const result = validate(validatePerson, person);
+            const result = validate(personValidator, person);
             expect(result.isValid).toBe(true);
         });
 
         it('nested objects', () => {
-            const validatePerson = objectProps({
+            const personValidator = objectProps({
                 name: every([required(), length(5, 40)]),
                 address: objectProps({
                     street: objectProps({
@@ -531,12 +531,12 @@ describe('docs', () => {
                 }
             };
 
-            const result = validate(validatePerson, person);
+            const result = validate(personValidator, person);
             expect(result.isValid).toBe(true);
         });
 
         it('conventions', () => {
-            const validatePerson = [
+            const personValidator = [
                 required(),
                 {
                     name: [required(), length(5, 40)],
@@ -565,7 +565,7 @@ describe('docs', () => {
                 }
             };
 
-            const result = validate(validatePerson, person);
+            const result = validate(personValidator, person);
             expect(result.isValid).toBe(false);
         });
     });

--- a/strickland/test/docs/form.spec.js
+++ b/strickland/test/docs/form.spec.js
@@ -7,7 +7,7 @@ import validate, {
 
 describe('docs', () => {
     describe('form validation', () => {
-        const validatePerson = form({
+        const personValidator = form({
             firstName: [
                 required(),
                 length(2, 20)
@@ -25,7 +25,7 @@ describe('docs', () => {
         };
 
         // Validate the firstName field
-        let result = validate(validatePerson, person, {
+        let result = validate(personValidator, person, {
             form: {
                 fields: ['firstName']
             }
@@ -63,7 +63,7 @@ describe('docs', () => {
 
                 // Validate the lastName field, build on
                 // previous form validation results
-                result = validate(validatePerson, person, {
+                result = validate(personValidator, person, {
                     form: {
                         ...result.form,
                         fields: ['lastName']
@@ -107,7 +107,7 @@ describe('docs', () => {
                 };
 
                 // Validate the birthYear field
-                result = validate(validatePerson, person, {
+                result = validate(personValidator, person, {
                     form: {
                         ...result.form,
                         fields: ['birthYear']
@@ -158,7 +158,7 @@ describe('docs', () => {
             });
 
             it('validates the entire form', () => {
-                result = validate(validatePerson, person, result);
+                result = validate(personValidator, person, result);
 
                 expect(result).toMatchObject({
                     isValid: false,
@@ -279,7 +279,7 @@ describe('docs', () => {
 
                 it('first field', () => {
                     // Validate the firstName field
-                    validationResult = validatePerson.validateFields(person, ['firstName']);
+                    validationResult = personValidator.validateFields(person, ['firstName']);
 
                     expect(validationResult).toMatchObject({
                         form: {
@@ -291,7 +291,7 @@ describe('docs', () => {
                 });
 
                 it('additional fields', () => {
-                    validationResult = validatePerson.validateFields(person, ['lastName'], validationResult)
+                    validationResult = personValidator.validateFields(person, ['lastName'], validationResult)
 
                     expect(validationResult).toMatchObject({
                         form: {
@@ -305,7 +305,7 @@ describe('docs', () => {
             });
 
             it('emptyResults', () => {
-                let validationResult = validatePerson.emptyResults();
+                let validationResult = personValidator.emptyResults();
 
                 expect(validationResult).toEqual({
                     form: {
@@ -324,7 +324,7 @@ describe('docs', () => {
                     birthYear: 1925
                 };
 
-                let stanfordResult = validate(validatePerson, stanfordStrickland);
+                let stanfordResult = validate(personValidator, stanfordStrickland);
 
                 let firstNameResult = {
                     isValid: false,
@@ -333,7 +333,7 @@ describe('docs', () => {
                 };
 
                 it('updates field results', () => {
-                    stanfordResult = validatePerson.updateFieldResults(
+                    stanfordResult = personValidator.updateFieldResults(
                         stanfordResult,
                         {firstName: firstNameResult}
                     );
@@ -367,7 +367,7 @@ describe('docs', () => {
                 });
 
                 it('removes field results', () => {
-                    stanfordResult = validatePerson.updateFieldResults(
+                    stanfordResult = personValidator.updateFieldResults(
                         stanfordResult,
                         {firstName: null}
                     );


### PR DESCRIPTION
BREAKING CHANGE:
The name of the `each` validator was not as intuitive. It has been renamed to `all`.