### PR TITLE
WIP: Add middleware support to the every validator

### DIFF
--- a/strickland/src/every.js
+++ b/strickland/src/every.js
@@ -5,15 +5,35 @@ const initialResult = {
     every: []
 };
 
+const defaultMiddleware = {
+    reduceResults: (nextReducer, previousResult, nextResult, {value, props, context}) => nextReducer(previousResult, nextResult),
+    prepareResult: (innerPrepareResult, result, {value, props, context}) => innerPrepareResult(result)
+};
+
 export default function everyValidator(validators, validatorProps) {
     if (!validators || !Array.isArray(validators)) {
         throw 'Strickland: The `every` validator expects an array of validators';
     }
 
     return function validateEvery(value, context) {
-        const props = typeof validatorProps === 'function' ?
+        const resolvedProps = typeof validatorProps === 'function' ?
             validatorProps(context) :
             validatorProps;
+
+        const {middleware = {}, ...props} = resolvedProps || {};
+        const {reduceResults = defaultMiddleware.reduceResults} = middleware;
+        const {prepareResult = defaultMiddleware.prepareResult} = middleware;
+
+        const middlewareProps = {
+            value,
+            props,
+            context
+        };
+
+        const middlewareCore = {
+            reduceResults: reduceResultsCore,
+            prepareResult: prepareResultCore.bind(null, {props})
+        };
 
         function executeValidators(currentResult, validatorsToExecute) {
             if (Array.isArray(validatorsToExecute) && validatorsToExecute.length) {
@@ -21,7 +41,16 @@ export default function everyValidator(validators, validatorProps) {
                     const previousResult = currentResult;
                     const nextResult = validate(validator, value, context);
 
-                    currentResult = applyNextResult(currentResult, nextResult);
+                    currentResult = reduceResults(
+                        middlewareCore.reduceResults,
+                        currentResult,
+                        nextResult,
+                        {
+                            value,
+                            props,
+                            context
+                        }
+                    ) || {};
 
                     if (nextResult.validateAsync) {
                         const previousAsync = previousResult.validateAsync || (() => Promise.resolve(previousResult));
@@ -29,7 +58,16 @@ export default function everyValidator(validators, validatorProps) {
                         currentResult.validateAsync = function resolveAsync() {
                             return previousAsync().then((resolvedPreviousResult) =>
                                 nextResult.validateAsync().then((resolvedNextResult) => {
-                                    let finalResult = applyNextResult(resolvedPreviousResult, resolvedNextResult);
+                                    let finalResult = reduceResults(
+                                        middlewareCore.reduceResults,
+                                        resolvedPreviousResult,
+                                        resolvedNextResult,
+                                        {
+                                            value,
+                                            props,
+                                            context
+                                        }
+                                    ) || {};
 
                                     if (finalResult.isValid) {
                                         const remainingValidators = validatorsToExecute.slice(index + 1);
@@ -40,10 +78,15 @@ export default function everyValidator(validators, validatorProps) {
                                         }
                                     }
 
-                                    return {
-                                        ...props,
-                                        ...finalResult
-                                    };
+                                    return prepareResult(
+                                        middlewareCore.prepareResult,
+                                        finalResult,
+                                        {
+                                            value,
+                                            props,
+                                            context
+                                        }
+                                    );
                                 })
                             );
                         };
@@ -61,21 +104,34 @@ export default function everyValidator(validators, validatorProps) {
 
         const result = executeValidators(initialResult, validators);
 
-        return {
-            ...props,
-            ...result
-        };
+        return prepareResult(
+            middlewareCore.prepareResult,
+            result,
+            {
+                value,
+                props,
+                context
+            }
+        );
     };
 }
 
-function applyNextResult(previousResult, nextResult) {
+function reduceResultsCore(previousResult, nextResult) {
+    // be sure to guard against middleware failing to provide isValid and every
     return {
         ...previousResult,
         ...nextResult,
-        isValid: previousResult.isValid && nextResult.isValid,
+        isValid: !!previousResult.isValid && !!nextResult.isValid,
         every: [
-            ...previousResult.every,
+            ...(previousResult.every || []),
             nextResult
         ]
+    };
+}
+
+function prepareResultCore({props}, result) {
+    return {
+        ...props,
+        ...result
     };
 }

--- a/strickland/test/every.spec.js
+++ b/strickland/test/every.spec.js
@@ -362,4 +362,363 @@ describe('every', () => {
             });
         });
     });
+
+    describe('supports middleware from validator props', () => {
+        it('omitting the middleware validator prop from the result', () => {
+            const middleware = {};
+
+            const validate = every([], {middleware});
+            const result = validate('ABC');
+
+            expect(result).not.toHaveProperty('middleware');
+        });
+
+        describe('for prepareResult', () => {
+            it('calling the middleware function with the expected args', () => {
+                const middleware = {
+                    prepareResult: jest.fn()
+                };
+
+                const props = {
+                    middleware,
+                    testProp: 'propValue'
+                };
+
+                const context = {
+                    contextProp: 'contextValue'
+                };
+
+                const validate = every([], props);
+                validate('ABC', context);
+
+                expect(middleware.prepareResult).toHaveBeenCalledWith(
+                    // core prepareResult function
+                    expect.any(Function),
+
+                    // result
+                    expect.objectContaining({
+                        isValid: true,
+                        every: []
+                    }),
+                    {
+                        value: 'ABC',
+                        props: expect.objectContaining({
+                            testProp: 'propValue'
+                        }),
+                        context
+                    }
+                );
+            });
+
+            it('allowing the core prepareResult function to be bypassed, omitting the every result prop', () => {
+                const middleware = {
+                    prepareResult: () => ({})
+                };
+
+                const validate = every([], {middleware});
+                const result = validate('ABC');
+
+                expect(result).not.toHaveProperty('every');
+            });
+
+            it('allowing the core prepareResult function to be called before returning the result', () => {
+                const middleware = {
+                    prepareResult(prepareResultCore, result) {
+                        const coreResult = prepareResultCore(result);
+
+                        return {
+                            ...coreResult,
+                            repeatedEvery: coreResult.every
+                        };
+                    }
+                };
+
+                const validate = every([required()], {middleware});
+                const result = validate('ABC');
+
+                expect(result).toMatchObject({
+                    isValid: true,
+                    every: [
+                        expect.objectContaining({
+                            isValid: true,
+                            required: true,
+                            value: 'ABC'
+                        })
+                    ],
+                    repeatedEvery: [
+                        expect.objectContaining({
+                            isValid: true,
+                            required: true,
+                            value: 'ABC'
+                        })
+                    ]
+                });
+            });
+
+            describe('allowing the core prepareResult function to be called with a different result object', () => {
+                const middleware = {
+                    prepareResult(prepareResultCore, result) {
+                        return prepareResultCore({different: 'result object'});
+                    }
+                };
+
+                const validate = every([required()], {middleware, validatorProp: 'validator prop'});
+                const result = validate('ABC');
+
+                it('while still merging that result and the validator props onto the final result', () => {
+                    expect(result).toMatchObject({
+                        different: 'result object',
+                        validatorProp: 'validator prop'
+                    });
+                });
+
+                it('but omitting original result props (every)', () => {
+                    expect(result).not.toHaveProperty('every');
+                });
+            });
+
+            describe('allowing the isValid result prop to be overridden', () => {
+                it('forcing it to false', () => {
+                    const middleware = {
+                        prepareResult: () => ({isValid: false})
+                    };
+
+                    const validate = every([], {middleware});
+                    const result = validate();
+
+                    expect(result.isValid).toBe(false);
+                });
+
+                it('forcing it to be true', () => {
+                    const middleware = {
+                        prepareResult: () => ({isValid: true})
+                    };
+
+                    const validate = every([required()], {middleware});
+                    const result = validate();
+
+                    expect(result.isValid).toBe(true);
+                });
+            });
+        });
+
+        describe('for reduceResults', () => {
+            it('calling the middleware function with the expected args', () => {
+                const middleware = {
+                    reduceResults: jest.fn()
+                };
+
+                const props = {
+                    middleware,
+                    testProp: 'propValue'
+                };
+
+                const context = {
+                    contextProp: 'contextValue'
+                };
+
+                const validate = every([required()], props);
+                validate('ABC', context);
+
+                expect(middleware.reduceResults).toHaveBeenCalledWith(
+                    // next reduceResult function
+                    expect.any(Function),
+
+                    // previous result
+                    expect.objectContaining({
+                        isValid: true,
+                        every: []
+                    }),
+
+                    // next result
+                    expect.objectContaining({
+                        isValid: true,
+                        required: true
+                    }),
+
+                    {
+                        value: 'ABC',
+                        props: expect.objectContaining({
+                            testProp: 'propValue'
+                        }),
+                        context
+                    }
+                );
+            });
+
+            it('allowing the core reduceResults function to be bypassed, therefore not populating the every result prop', () => {
+                const middleware = {
+                    reduceResults(nextReducer, previousResult, nextResult) {
+                        return {
+                            ...previousResult,
+                            ...nextResult
+                        };
+                    }
+                };
+
+                const validate = every([required()], {middleware});
+                const result = validate('ABC');
+
+                expect(result.every).toHaveLength(0);
+            });
+
+            it('allowing the core reduceResults function to be called before returning the result', () => {
+                const middleware = {
+                    reduceResults(nextReducer, previousResult, nextResult) {
+                        const coreResult = nextReducer(previousResult, nextResult);
+
+                        return {
+                            ...coreResult,
+                            every: [
+                                ...coreResult.every,
+                                {
+                                    extraResult: true
+                                }
+                            ]
+                        };
+                    }
+                };
+
+                const validate = every([required()], {middleware});
+                const result = validate('ABC');
+
+                expect(result).toMatchObject({
+                    isValid: true,
+                    every: [
+                        expect.objectContaining({
+                            isValid: true,
+                            required: true,
+                            value: 'ABC'
+                        }),
+                        expect.objectContaining({
+                            extraResult: true
+                        })
+                    ]
+                });
+            });
+
+            describe('allowing the core reduceResults function to be called with different result objects', () => {
+                const middleware = {
+                    reduceResults(nextReducer, previousResult, nextResult) {
+                        return nextReducer(
+                            {
+                                ...previousResult,
+                                previousResult: 'replaced previous'
+                            },
+                            {
+                                ...nextResult,
+                                nextResult: 'replaced next'
+                            }
+                        );
+                    }
+                };
+
+                const validate = every([required()], {middleware});
+                const result = validate('ABC');
+
+                it('while still merging that the supplied result objects', () => {
+                    expect(result).toMatchObject({
+                        isValid: true,
+                        previousResult: 'replaced previous',
+                        nextResult: 'replaced next'
+                    });
+                });
+
+                it('and still adding the next result to the `every` result prop array', () => {
+                    expect(result.every).toEqual([
+                        expect.objectContaining({
+                            isValid: true,
+                            nextResult: 'replaced next'
+                        })
+                    ]);
+                });
+
+                it('guarding against the failure to include the `every` prop on the previous result', () => {
+                    const badMiddleware = {
+                        reduceResults(nextReducer, previousResult, nextResult) {
+                            return nextReducer(
+                                {
+                                    previousResult: 'replaced previous'
+                                },
+                                {
+                                    nextResult: 'replaced next'
+                                }
+                            );
+                        }
+                    };
+
+                    const validate = every([required(), minLength(1)], {middleware: badMiddleware});
+                    const result = validate('ABC');
+
+                    expect(result).toMatchObject({
+                        previousResult: 'replaced previous',
+                        nextResult: 'replaced next',
+                        every: [
+                            expect.objectContaining({
+                                nextResult: 'replaced next'
+                            })
+                        ]
+                    });
+                });
+
+                it('guarding against the failure to include the `isValid` result props (defaulting to false)', () => {
+                    const badMiddleware = {
+                        reduceResults(nextReducer, previousResult, nextResult) {
+                            return nextReducer(
+                                {
+                                    previousResult: 'replaced previous'
+                                },
+                                {
+                                    nextResult: 'replaced next'
+                                }
+                            );
+                        }
+                    };
+
+                    const validate = every([required(), minLength(1)], {middleware: badMiddleware});
+                    const result = validate('ABC');
+
+                    expect(result).toMatchObject({
+                        previousResult: 'replaced previous',
+                        nextResult: 'replaced next',
+                        isValid: false
+                    });
+                });
+            });
+
+            describe('allowing the isValid result prop to be overridden', () => {
+                it('forcing it to false', () => {
+                    const middleware = {
+                        reduceResults(nextReducer, previousResult, nextResult) {
+                            return {
+                                ...nextReducer(previousResult, nextResult),
+                                isValid: false
+                            };
+                        }
+                    };
+
+                    const validate = every([required()], {middleware});
+                    const result = validate('ABC');
+
+                    expect(result.isValid).toBe(false);
+                });
+
+                it('forcing it to be true', () => {
+                    const middleware = {
+                        reduceResults(nextReducer, previousResult, nextResult) {
+                            return {
+                                ...nextReducer(previousResult, nextResult),
+                                isValid: true
+                            };
+                        }
+                    };
+
+                    const validate = every([required()], {middleware});
+                    const result = validate();
+
+                    expect(result.isValid).toBe(true);
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
This illustrates what a middleware contract could look like for the `every` validator to support `reduceResults` and `prepareResult` middleware, that can wrap or override the default behavior of how results are aggregated.

The contract for middleware is:

``` js
const middleware = {
    reduceResults(nextReducer, accumulator, currentResult, { value, props, context }) {
        // This behaves as a passthrough middleware
        // The { value, props, context } argument will be provided automatically and it cannot be mutated
        return nextReducer(accumulator, currentResult);
    },
    prepareResult(nextPrepare, result, { value, props, context }) {
        // This behaves as a passthrough middleware
        // The { value, props, context } argument will be provided automatically and it cannot be mutated
        return nextPrepare(result);
    }
};
```

This `middleware` can be supplied:

1. As part of the validator props
2. As part of the validation context

You can also supply an array of `middleware` objects. The last middleware will be invoked first. The validation context middleware(s) are executed before the validator props middleware(s).